### PR TITLE
Bump runtime to 40

### DIFF
--- a/net.danigm.timetrack.json
+++ b/net.danigm.timetrack.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.danigm.timetrack",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.36",
+    "runtime-version" : "40",
     "sdk" : "org.gnome.Sdk",
     "command" : "timetrack",
     "finish-args" : [


### PR DESCRIPTION
Last thing that requires the `3.36` runtime on my machine. The test build works perfectly.

@danigm